### PR TITLE
Update package name and urls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,16 @@ authors = [
 ]
 description = "A simple gerber parser for the gerber-types crate"
 readme = "README.md" 
-documentation = "https://docs.rs/gerber_parser"
+documentation = "https://docs.rs/gerber-parser"
 license = "AGPL-3.0"
-homepage = "https://github.com/NemoAndrea/gerber-parser"
-repository = "https://github.com/NemoAndrea/gerber-parser" 
+homepage = "https://github.com/MakerPnP/gerber-parser"
+repository = "https://github.com/MakerPnP/gerber-parser"
 
 
 [dependencies]
-# currently un-released, using latest gerber-types with updates to support macro expressions
-#gerber-types = "0.4.0"
-gerber-types = { git = "https://github.com/makerpnp/gerber-types-rs.git", rev = "351ef9150fdc4be735ce0d22542f0c333c3aefd2"}
+# currently un-released, using latest gerber_types with updates to support macro expressions
+#gerber_types = "0.4.0"
+gerber_types = { git = "https://github.com/MakerPnP/gerber-types.git", rev = "7641a4c92482411b6a05a5dc36793151763b40e6"}
 
 # errors
 thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 [![Crates.io][crates-io-badge]][crates-io]
 [![MakerPnP Discord][discord-badge]][discord]
 
-- [Docs (released)](https://docs.rs/gerber-types/)
+- [Docs (released)](https://docs.rs/gerber-parser/)
 
 This crate implements a `gerber` parser written in rust to be used with the `gerber-types-rs` crate.
 
 ## Example
 
-See the `examples` folder of the repository.
+See the `examples` folder of the repository, run it as follows:
+
+    $ cargo run --example example1
 
 ## Spec compliance
 
@@ -29,6 +31,28 @@ Partial:
 
 * The `TF` and `TA` commands only support a limited range of arguments; custom attributes will result in an error
 
+## Related crates
+
+### Gerber Types
+
+A rust crate for definition of gerber types in test.
+
+Crates.io: https://crates.io/crates/gerber-types
+Github: https://github.com/MakerPnP/gerber-types
+
+### Gerber Viewer
+
+A rust crate for rendering gerber layers, also uses this crate as a dependency:
+
+Github: https://github.com/MakerPnP/gerber-viewer
+
+## Related projects
+
+For a list of other projects that use this crate you can check the github 'dependents' page.
+
+https://github.com/MakerPnP/gerber-parser/network/dependents
+
+
 ## Authors
 
 Nemo Andrea (Original author)
@@ -45,7 +69,7 @@ Dominic Clifton (Current maintainer)
 
 [build-status]: https://github.com/makerpnp/gerber-parser/actions/workflows/ci.yml
 [build-status-badge]: https://github.com/makerpnp/gerber-parser/workflows/CI/badge.svg
-[crates-io]: https://crates.io/crates/gerber_parser
-[crates-io-badge]: https://img.shields.io/crates/v/gerber_parser.svg
+[crates-io]: https://crates.io/crates/gerber-parser
+[crates-io-badge]: https://img.shields.io/crates/v/gerber-parser.svg
 [discord]: https://discord.gg/ffwj5rKZuf
 [discord-badge]: https://img.shields.io/discord/1255867192503832688?label=MakerPnP%20discord&color=%2332c955


### PR DESCRIPTION
* attempting to be consistent between the 3 gerber crates. (types, parser, viewer).
* using '_' in package name.
* using '-' in urls. (crates.io accepts either, github doesn't redirect).