### PR TITLE
Bump MSRV matrix to 1.85.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.80.0"
+          - "1.85.0"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
uuid 1.23.1 (transitive via gerber-types) requires rustc 1.85, so the prior 1.80.0 job no longer builds.

Fixes: #18 