### PR TITLE
Allow negative I/J offsets in step-and-repeat.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,7 +57,7 @@ static RE_INTERPOLATION: Lazy<Regex> =
 static RE_MOVE_OR_FLASH: Lazy<Regex> = lazy_regex!(r"X?(-?[0-9]+)?Y?(-?[0-9]+)?D(0)?[2-3]*");
 static RE_IMAGE_NAME: Lazy<Regex> = lazy_regex!(r"%IN(.*)\*%");
 static RE_STEP_REPEAT: Lazy<Regex> =
-    lazy_regex!(r"%SRX([0-9]+)Y([0-9]+)I(\d+\.?\d*)J(\d+\.?\d*)\*%");
+    lazy_regex!(r"%SRX([0-9]+)Y([0-9]+)I(-?\d+\.?\d*)J(-?\d+\.?\d*)\*%");
 static RE_MACRO_UNSIGNED_INTEGER: Lazy<Regex> =
     lazy_regex!(r"^(?:(?P<value>[0-9]+)|(?P<variable>\$[0-9]+)|(?P<expression>.*))$");
 static RE_MACRO_BOOLEAN: Lazy<Regex> =

--- a/tests/component_tests.rs
+++ b/tests/component_tests.rs
@@ -780,7 +780,7 @@ fn test_load_scaling_zero() {
     ));
 }
 
-/// Test Step and Repeat command (%SR*%)
+/// Test Step and Repeat command (%SR*%), including negative I/J offsets.
 #[test]
 fn step_and_repeat() {
     // given
@@ -800,7 +800,11 @@ fn step_and_repeat() {
     X-1000Y-30000D01*
     %SR*%
 
-    M02*        
+    %SRX12Y6I-3.33J-8.120*%
+    X0Y0D01*
+    %SR*%
+
+    M02*
     ",
     );
 
@@ -820,6 +824,17 @@ fn step_and_repeat() {
                     repeat_y: 6,
                     distance_x: 3.33,
                     distance_y: 8.12,
+                }
+            ))),
+            Ok(Command::ExtendedCode(ExtendedCode::StepAndRepeat(
+                StepAndRepeat::Close
+            ))),
+            Ok(Command::ExtendedCode(ExtendedCode::StepAndRepeat(
+                StepAndRepeat::Open {
+                    repeat_x: 12,
+                    repeat_y: 6,
+                    distance_x: -3.33,
+                    distance_y: -8.12,
                 }
             ))),
             Ok(Command::ExtendedCode(ExtendedCode::StepAndRepeat(


### PR DESCRIPTION
RS-274X spec section 4.5.3 does not restrict SR I/J step values to positive numbers. Regex previously rejected negatives, causing parse failures on real-world files. Loosen pattern and extend existing test to cover negative case.